### PR TITLE
[meson] BuildRequire python3-setuptools. JB#54767

### DIFF
--- a/rpm/meson.spec
+++ b/rpm/meson.spec
@@ -10,6 +10,7 @@ Source:         %{name}-%{version}.tar.bz2
 Patch0:         0001-patch-macros.patch
 BuildArch:      noarch
 BuildRequires:  python3-devel >= 3.5.0
+BuildRequires:  python3-setuptools
 Requires:       ninja >= 1.7.0
 # Workaround ccache autodetection not working on OBS arm builds, JB#42632
 Requires:       ccache


### PR DESCRIPTION
Do not assume python3-setuptools is preinstalled.
Fixes regression introduced by e597dd12f8168ea4660a6fca1b346c776e0e8b55.

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>